### PR TITLE
add support for use of context path

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ spring.bulk.api.limit=200 # default is 100
 }
 
 ```
-+ url - the API endpoint. (required)
++ url - the API endpoint, relative to your application context path. (required)
 + method - the HTTP method(GET, POST, DELETE ...etc.) Default is GET. (optional)
 + params - the HTTP parameters to the API. (optional)
 + headers - a hash of of headers which should be included in this operation. (optional)

--- a/src/main/java/com/github/wnameless/spring/bulkapi/DefaultBulkApiService.java
+++ b/src/main/java/com/github/wnameless/spring/bulkapi/DefaultBulkApiService.java
@@ -110,16 +110,16 @@ public class DefaultBulkApiService implements BulkApiService {
   private ComputedURIResult computeUri(HttpServletRequest servReq,
       BulkOperation op) {
     String rawUrl = servReq.getRequestURL().toString();
-    String rawUri = servReq.getRequestURI().toString();
+    String bulkPath = urlify(env.getProperty("spring.bulk.api.path", "/bulk"));
 
     if (op.getUrl() == null || isBulkPath(op.getUrl())) {
       throw new BulkApiException(UNPROCESSABLE_ENTITY,
-          "Invalid URL(" + rawUri + ") exists in this bulk request");
+          "Invalid URL(" + bulkPath + ") exists in this bulk request");
     }
 
     URI uri;
     try {
-      String servletPath = rawUrl.substring(0, rawUrl.indexOf(rawUri));
+      String servletPath = rawUrl.substring(0, rawUrl.lastIndexOf(bulkPath));
       uri = new URI(servletPath + urlify(op.getUrl()));
     } catch (URISyntaxException e) {
       throw new BulkApiException(UNPROCESSABLE_ENTITY, "Invalid URL("


### PR DESCRIPTION
Proposed change for computing the urls of the destination services:
Instead fo assuming the destination endpoints are bound to the '/' base context, it assumes that the destination endpoints are on the same context than the bulk service.
